### PR TITLE
Fetch Upstash blog posts from live feed at build time

### DIFF
--- a/src/data/external-posts.ts
+++ b/src/data/external-posts.ts
@@ -1,9 +1,13 @@
 import type { TagKey } from './tags';
 
 /**
- * Posts published on external sites (e.g. the Upstash blog). These show up in the
- * content list as link-out cards - no local page. To add one, append a single entry
- * below; no new file needed. (`tags` defaults to ['blog'].)
+ * Posts published on external sites (the Upstash blog). These show up in the content
+ * list as link-out cards - no local page.
+ *
+ * The live list is fetched at build time from my Upstash author feed (see
+ * `lib/upstash-feed.ts`), so new Upstash posts appear automatically. This array is the
+ * offline fallback used only when that feed is unreachable; keep it roughly in sync.
+ * (`tags` defaults to ['blog'].)
  */
 export interface ExternalPost {
   title: string;

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -1,7 +1,7 @@
 import { getCollection } from 'astro:content';
 import type { ImageMetadata } from 'astro';
 import type { TagKey } from '../data/tags';
-import { externalPosts } from '../data/external-posts';
+import { getExternalPosts } from './upstash-feed';
 import { getProjects } from './github';
 
 /**
@@ -36,8 +36,9 @@ export async function getEntries(): Promise<ListEntry[]> {
     heroImage: entry.data.heroImage,
   }));
 
-  // External posts (Upstash, etc.) - link-out cards, maintained in one data file.
-  const externalEntries: ListEntry[] = externalPosts.map((post) => ({
+  // External posts (Upstash) - link-out cards, sourced from my Upstash author feed
+  // at build time (with a committed fallback list if the feed is unreachable).
+  const externalEntries: ListEntry[] = (await getExternalPosts()).map((post) => ({
     title: post.title,
     description: post.description,
     date: new Date(post.date),

--- a/src/lib/upstash-feed.ts
+++ b/src/lib/upstash-feed.ts
@@ -1,0 +1,93 @@
+import type { ExternalPost } from '../data/external-posts';
+import { externalPosts as fallbackPosts } from '../data/external-posts';
+
+/**
+ * Build-time fetch of my Upstash author feed. This is the source of truth for the
+ * Upstash link-out cards: publish a post on Upstash and it shows up here on the next
+ * build, no edit needed. Every failure mode (offline, non-200, unexpected/empty XML)
+ * resolves to the committed `externalPosts` list so a build never breaks - and a feed
+ * outage can't blank the section.
+ */
+
+const FEED_URL = 'https://upstash.com/blog/author/arda/feed.xml';
+const SOURCE = 'Upstash';
+
+// Fetch once per build and reuse - the index and command palette both ask for entries.
+let cache: Promise<ExternalPost[]> | null = null;
+
+// Minimal entity decode. Fields are CDATA-wrapped (so usually literal), but decode the
+// common five in case a field is ever emitted as plain escaped text.
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#3?9;|&#x27;/gi, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// Pull one tag's text out of an <item> block, unwrapping CDATA. Returns '' if absent.
+function tag(item: string, name: string): string {
+  const m = item.match(new RegExp(`<${name}[^>]*>([\\s\\S]*?)</${name}>`));
+  if (!m) return '';
+  const inner = m[1].trim();
+  const cdata = inner.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+  return decodeEntities((cdata ? cdata[1] : inner).trim());
+}
+
+function parseFeed(xml: string): ExternalPost[] {
+  // Drop the heavy HTML bodies first so per-item field extraction stays unambiguous.
+  const cleaned = xml.replace(/<content:encoded>[\s\S]*?<\/content:encoded>/g, '');
+
+  const posts: ExternalPost[] = [];
+  for (const m of cleaned.matchAll(/<item>([\s\S]*?)<\/item>/g)) {
+    const item = m[1];
+    const title = tag(item, 'title');
+    const url = tag(item, 'link');
+    const pubDate = tag(item, 'pubDate');
+    const description = tag(item, 'description');
+
+    const date = new Date(pubDate);
+    if (!title || !url || Number.isNaN(date.valueOf())) continue;
+
+    posts.push({
+      title,
+      description,
+      date: date.toISOString().slice(0, 10), // YYYY-MM-DD
+      url,
+      source: SOURCE,
+    });
+  }
+
+  return posts.sort((a, b) => b.date.localeCompare(a.date));
+}
+
+async function fetchExternalPosts(): Promise<ExternalPost[]> {
+  try {
+    const res = await fetch(FEED_URL, {
+      headers: { 'User-Agent': 'cahidarda.github.io-build', Accept: 'application/rss+xml' },
+    });
+    if (!res.ok) {
+      console.warn(`[upstash-feed] fetch failed: ${res.status} ${res.statusText}; using fallback`);
+      return fallbackPosts;
+    }
+    const posts = parseFeed(await res.text());
+    if (posts.length === 0) {
+      console.warn('[upstash-feed] parsed 0 items; using fallback');
+      return fallbackPosts;
+    }
+    return posts;
+  } catch (err) {
+    console.warn(
+      '[upstash-feed] fetch error:',
+      err instanceof Error ? err.message : err,
+      '; using fallback',
+    );
+    return fallbackPosts;
+  }
+}
+
+export async function getExternalPosts(): Promise<ExternalPost[]> {
+  cache ??= fetchExternalPosts();
+  return cache;
+}


### PR DESCRIPTION
## Summary
Replaced the static list of external posts with a dynamic build-time fetch from the Upstash author feed. New Upstash blog posts now appear automatically on the next build without manual edits, while maintaining a committed fallback list for offline resilience.

## Key Changes
- **New module `src/lib/upstash-feed.ts`**: Fetches and parses the Upstash author RSS feed at build time
  - Implements robust XML parsing with CDATA unwrapping and HTML entity decoding
  - Gracefully falls back to the committed `externalPosts` list on any failure (network, non-200 status, parse errors, empty results)
  - Caches the result per build to avoid redundant fetches
  
- **Updated `src/lib/entries.ts`**: Changed to call `getExternalPosts()` instead of importing the static list
  - Now awaits the async feed fetch during build
  
- **Updated `src/data/external-posts.ts`**: Clarified that the array is now a fallback
  - Documented the automatic feed sync behavior and maintenance expectations

## Implementation Details
- Feed URL: `https://upstash.com/blog/author/arda/feed.xml`
- Parses RSS items and extracts title, link, pubDate, and description
- Converts dates to ISO 8601 format (YYYY-MM-DD) and sorts by date descending
- All error modes (offline, HTTP errors, malformed XML, empty feed) log a warning and return the fallback list—builds never break due to feed issues
- Minimal XML parsing implementation avoids external dependencies

https://claude.ai/code/session_015pNaeEhMnuv5KnEFYpquCm