### PR TITLE
Add two new Upstash repositories to EXTRA_REPOS

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -16,6 +16,8 @@ const EXTRA_REPOS = [
   'upstash/workflow-js',
   'upstash/degree-guru',
   'upstash/box',
+  'upstash/workflow-agents-js',
+  'upstash/agent-analytics',
 ];
 
 // Lenient: many repos lack a description, homepage, or language.


### PR DESCRIPTION
## Summary
Added two new Upstash repositories to the `EXTRA_REPOS` configuration in the GitHub utilities module.

## Changes
- Added `upstash/workflow-agents-js` to the repository list
- Added `upstash/agent-analytics` to the repository list

These repositories are now included in the extra repositories that are processed by the GitHub integration, expanding the scope of repositories being tracked or analyzed by this module.

https://claude.ai/code/session_01BHy6naNQGWFyiGx8GNatuy