### PR TITLE
Add sitemap redirect and robots.txt for SEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,11 @@ export default defineConfig({
   },
   integrations: [react(), mdx(), sitemap()],
 
+  // @astrojs/sitemap emits /sitemap-index.xml; redirect the conventional URL to it.
+  redirects: {
+    '/sitemap.xml': '/sitemap-index.xml',
+  },
+
   vite: {
     plugins: [tailwindcss()],
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://cahidarda.github.io/sitemap-index.xml


### PR DESCRIPTION
## Summary
This PR improves SEO configuration by adding a sitemap redirect and creating a robots.txt file to guide search engine crawlers.

## Key Changes
- **Sitemap redirect**: Added a redirect rule in `astro.config.mjs` to map the conventional `/sitemap.xml` URL to the actual `/sitemap-index.xml` generated by `@astrojs/sitemap`
- **Robots.txt**: Created a new `public/robots.txt` file that allows all crawlers and points them to the sitemap location

## Implementation Details
The `@astrojs/sitemap` integration generates a sitemap at `/sitemap-index.xml` rather than the conventional `/sitemap.xml` path. The redirect ensures that any crawlers or tools looking for the standard location are automatically directed to the correct file. The robots.txt file provides explicit crawler instructions and sitemap discovery, improving search engine indexing.

https://claude.ai/code/session_011Etm4ns5Gs7PJ7JeEQuBSB