### PR TITLE
Add upstash/eve-example to EXTRA_REPOS list

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -18,6 +18,7 @@ const EXTRA_REPOS = [
   'upstash/box',
   'upstash/workflow-agents-js',
   'upstash/agent-analytics',
+  'upstash/eve-example',
 ];
 
 // Lenient: many repos lack a description, homepage, or language.


### PR DESCRIPTION
## Summary
Added the `upstash/eve-example` repository to the list of extra repositories that are included in the GitHub data source.

## Changes
- Added `'upstash/eve-example'` to the `EXTRA_REPOS` array in `src/lib/github.ts`

## Details
This change expands the set of Upstash repositories that are tracked and included in the application's GitHub integration. The repository is now part of the curated list of additional repositories beyond the primary data source.

https://claude.ai/code/session_01VEzvy69TVVNqJkWr3ifWhu